### PR TITLE
Return xr.DataArray objects

### DIFF
--- a/mlpp_features/__init__.py
+++ b/mlpp_features/__init__.py
@@ -1,4 +1,4 @@
-from mlpp_features import utils  # load the accessor
+from mlpp_features import accessors  # load the accessor
 
 from mlpp_features.nwp import *
 from mlpp_features.obs import *

--- a/mlpp_features/accessors.py
+++ b/mlpp_features/accessors.py
@@ -2,7 +2,6 @@
 import logging
 from dataclasses import dataclass, field
 from typing import List, Union
-from functools import wraps
 
 import numpy as np
 import xarray as xr
@@ -82,16 +81,3 @@ class PreprocDatasetAccessor:
         Apply a function to the input dataset.
         """
         return f(self.ds)
-
-
-def asarray(func):
-    @wraps(func)
-    def inner(*args, **kwargs):
-        out = func(*args, **kwargs)
-        if isinstance(out, xr.Dataset):
-            out = out.to_array(name=func.__name__).sequeeze("variable", drop=True)
-        elif isinstance(out, xr.DataArray):
-            out = out.rename(func.__name__)
-        return out
-
-    return inner

--- a/mlpp_features/decorators.py
+++ b/mlpp_features/decorators.py
@@ -1,0 +1,16 @@
+from functools import wraps
+import xarray as xr 
+
+def asarray(func):
+    """
+    Make every feature function return a DataArray names like the function itself.
+    """
+    @wraps(func)
+    def inner(*args, **kwargs):
+        out = func(*args, **kwargs)
+        if isinstance(out, xr.Dataset):
+            out = out.to_array(name=func.__name__).squeeze("variable", drop=True)
+        elif isinstance(out, xr.DataArray):
+            out = out.rename(func.__name__)
+        return out
+    return inner

--- a/mlpp_features/nwp.py
+++ b/mlpp_features/nwp.py
@@ -4,7 +4,7 @@ from typing import Dict
 import xarray as xr
 import numpy as np
 
-from mlpp_features.utils import asarray
+from mlpp_features.decorators import asarray
 
 LOGGER = logging.getLogger(__name__)
 

--- a/mlpp_features/obs.py
+++ b/mlpp_features/obs.py
@@ -4,7 +4,7 @@ from typing import Dict
 import xarray as xr
 import numpy as np
 
-from mlpp_features.utils import asarray
+from mlpp_features.decorators import asarray
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Every feature returns a `xr.DataArray` object instead of a dataset.

The main motivation is that some features are constructed by combining and doing computation with other features, but xarray doesn't allow to do computations between multiple datasets unless they have the same variables names.

Changes (2285a13139f22a340ee2c63b498fc352ec573fa4, 25c84657c5fc521260ca4e15f8715d81f6e4ca25)
* added `asarray()` decorator
* added some features

While I was at it, I also:
* did some refactoring of the obs features (63d57d1ddb59391dff61fee173b3740fb6557fd2) 
* fixed a couple of bugs (d0e323a2dc8d11ab506cfbc37c1347a3fb631d7f, 98d673485e71a2d05acc172efb37015b312d7c7e)

The only change required in mlpp-workflows will be [here](https://github.com/MeteoSwiss/mlpp-workflows/blob/193ea110415e236416f3fee4e8147880928b91c2/workflow/scripts/preproc_source.py#L149-L161), where we will remove the `to_array()` method.
```python
ds[feature] = output.to_array().squeeze(drop=True)
```