### PR TITLE
WIP: add targets

### DIFF
--- a/mlpp_features/targets.py
+++ b/mlpp_features/targets.py
@@ -1,0 +1,17 @@
+import logging
+from typing import Dict
+
+import xarray as xr
+import numpy as np
+
+from mlpp_features.decorators import asarray
+
+LOGGER = logging.getLogger(__name__)
+
+# Set global options
+xr.set_options(keep_attrs=True)
+
+
+@asarray
+def wind_speed(data: xr.Dataset) -> xr.DataArray:
+    return data["obs"]["wind_speed"].astype("float32")


### PR DESCRIPTION
This PR adds the possibility to create targets.

It is developed along with another PR in MeteoSwiss/mlpp-workflows#7. 

Before we continue, a few things need some thought (@dnerini, @sadamov):
* adding a `targets.py` file in a "features" repository can be a bit confusing. Another example: we would have both `obs.py` and `targets.py` files...also confusing. Maybe we could think of changing some names?
* about the data that will be ingested by functions in this repo (i.e. data that is created in mlpp-workflows): how does it look like?
* it's a good idea if in these cases we try to coordinate the development in mlpp-workflows with the development in this repo, maybe with some cross-referencing


Following @dnerini's comment https://github.com/MeteoSwiss/mlpp-features/pull/2#issuecomment-1027926552 we opt for another approach. Instead of creating a new targets.py file, we do not distinguish between predictors and predictands. 

So we will simply create new functions that behave the same as we have at the moment, i.e. taking the `data` dictionary with all the sources needed to compute the required features. In `obs.py` we will have everything derived purely from observations. 