### PR TITLE
Reuse pipelines results

### DIFF
--- a/mlpp_features/decorators.py
+++ b/mlpp_features/decorators.py
@@ -29,12 +29,15 @@ def asarray(func):
 def reuse(func):
     """
     If the feature already exists in the target dataset, reuse it instead of computing it again.
+    The target dataset is where the pipelines' results are accumulated, and can be passed
+    as a keyword argument named `ds`.
     """
 
     @wraps(func)
     def inner(*args, **kwargs):
-        if func.__name__ in kwargs["ds"].data_vars:
-            out = args[-1][func.__name__]
+        ds = kwargs.get("ds", xr.Dataset())
+        if func.__name__ in ds.data_vars:
+            out = ds[func.__name__]
         else:
             out = func(*args, **kwargs)
         return out

--- a/mlpp_features/discover.py
+++ b/mlpp_features/discover.py
@@ -18,9 +18,7 @@ def discover_inputs(pipelines: Union[str, List[str]]) -> List:
     inputs = []
     for pipeline in pipelines:
         try:
-            getattr(globals()["mlpp_features"], pipeline)(
-                data, None, None, None, ds=xr.Dataset()
-            )
+            getattr(globals()["mlpp_features"], pipeline)(data, None, None, None)
         except KeyError as err:
             var = err.args[0]
             if isinstance(var, str):

--- a/mlpp_features/nwp.py
+++ b/mlpp_features/nwp.py
@@ -15,12 +15,7 @@ xr.set_options(keep_attrs=True)
 @reuse
 @asarray
 def average_downward_longwave_radiation_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of average downward longwave radiation
@@ -38,12 +33,7 @@ def average_downward_longwave_radiation_ensavg(
 @reuse
 @asarray
 def boundary_layer_height_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of boundary layer height
@@ -61,12 +51,7 @@ def boundary_layer_height_ensavg(
 @reuse
 @asarray
 def cos_wind_from_direction_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Calculate ensemble mean of cosine wind direction
@@ -87,12 +72,7 @@ def cos_wind_from_direction_ensavg(
 @reuse
 @asarray
 def dew_point_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of dew point temperature
@@ -111,12 +91,7 @@ def dew_point_ensavg(
 @reuse
 @asarray
 def diffuse_downward_shortwave_radiation_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of diffuse downward shortwave radiation
@@ -134,12 +109,7 @@ def diffuse_downward_shortwave_radiation_ensavg(
 @reuse
 @asarray
 def diffuse_upward_shortwave_radiation_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of diffuse upward shortwave radiation
@@ -157,12 +127,7 @@ def diffuse_upward_shortwave_radiation_ensavg(
 @reuse
 @asarray
 def direct_downward_shortwave_radiation_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of direct downward shortwave radiation
@@ -180,12 +145,7 @@ def direct_downward_shortwave_radiation_ensavg(
 @reuse
 @asarray
 def eastward_wind_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of average downward longwave radiation
@@ -203,12 +163,7 @@ def eastward_wind_ensavg(
 @reuse
 @asarray
 def heat_index_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
 
     # try/except block necessary to expose all the required input data
@@ -218,12 +173,8 @@ def heat_index_ensavg(
     except KeyError:
         raise KeyError(["air_temperature", "dew_point_temperature"])
 
-    t_celsius = temperature_ensavg(
-        data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-    )
-    u = relative_humidity_ensavg(
-        data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-    )
+    t_celsius = temperature_ensavg(data, stations, reftimes, leadtimes, **kwargs)
+    u = relative_humidity_ensavg(data, stations, reftimes, leadtimes, **kwargs)
 
     def _hi_normal_range(t_f, u):
         return (
@@ -253,14 +204,7 @@ def heat_index_ensavg(
 
 @reuse
 @asarray
-def leadtime(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
-):
+def leadtime(data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs):
     """
     Extract leadtime in hours
     """
@@ -279,12 +223,7 @@ def leadtime(
 @reuse
 @asarray
 def model_height_difference(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Difference between model height and height from the more precise DEM
@@ -306,12 +245,7 @@ def model_height_difference(
 @reuse
 @asarray
 def northward_wind_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of average downward longwave radiation
@@ -329,12 +263,7 @@ def northward_wind_ensavg(
 @reuse
 @asarray
 def pressure_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of surface pressure
@@ -352,12 +281,7 @@ def pressure_ensavg(
 @reuse
 @asarray
 def pressure_difference_BAS_LUG_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of surface pressure
@@ -377,12 +301,7 @@ def pressure_difference_BAS_LUG_ensavg(
 @reuse
 @asarray
 def pressure_difference_GVE_GUT_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of surface pressure
@@ -403,21 +322,14 @@ def pressure_difference_GVE_GUT_ensavg(
 @reuse
 @asarray
 def relative_humidity_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of relative humidity
     """
-    e = water_vapor_pressure_ensavg(
-        data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-    )
+    e = water_vapor_pressure_ensavg(data, stations, reftimes, leadtimes, **kwargs)
     e_s = water_vapor_saturation_pressure_ensavg(
-        data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
+        data, stations, reftimes, leadtimes, **kwargs
     )
 
     return (e / e_s * 100).astype("float32")
@@ -426,12 +338,7 @@ def relative_humidity_ensavg(
 @reuse
 @asarray
 def sin_wind_from_direction_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Calculate ensemble mean of sine wind direction
@@ -452,12 +359,7 @@ def sin_wind_from_direction_ensavg(
 @reuse
 @asarray
 def specific_humidity_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of specific humidity
@@ -475,12 +377,7 @@ def specific_humidity_ensavg(
 @reuse
 @asarray
 def sunshine_duration_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of sunshine duration
@@ -498,12 +395,7 @@ def sunshine_duration_ensavg(
 @reuse
 @asarray
 def sx_500m(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Extract Sx with a 500m radius, for azimuth sectors of 10 degrees
@@ -515,9 +407,7 @@ def sx_500m(
 
     # find correct index for every sample
     wdir = (
-        wind_from_direction_ensavg(
-            data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-        )
+        wind_from_direction_ensavg(data, stations, reftimes, leadtimes, **kwargs)
         .astype("int16")
         .load()
     )
@@ -536,12 +426,7 @@ def sx_500m(
 @reuse
 @asarray
 def temperature_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of temperature
@@ -560,12 +445,7 @@ def temperature_ensavg(
 @reuse
 @asarray
 def water_vapor_mixing_ratio_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     # try/except block necessary to expose all the required input data
     try:
@@ -578,29 +458,18 @@ def water_vapor_mixing_ratio_ensavg(
         )
 
     try:
-        q = specific_humidity_ensavg(
-            data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-        )
+        q = specific_humidity_ensavg(data, stations, reftimes, leadtimes, **kwargs)
         return (q / (1 - q)).astype("float32")
     except KeyError:
-        e = water_vapor_pressure_ensavg(
-            data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-        )
-        p = pressure_ensavg(
-            data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-        )
+        e = water_vapor_pressure_ensavg(data, stations, reftimes, leadtimes, **kwargs)
+        p = pressure_ensavg(data, stations, reftimes, leadtimes, **kwargs)
         return ((622.0 * e) / (p / 100 - e)).astype("float32")
 
 
 @reuse
 @asarray
 def water_vapor_pressure_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     # try/except block necessary to expose all the required input data
     try:
@@ -610,11 +479,9 @@ def water_vapor_pressure_ensavg(
         raise KeyError(["dew_point_temperature", "air_temperature"])
 
     dew_point_temperature = dew_point_ensavg(
-        data, stations, reftimes, leadtimes, ds=xr.Dataset()
+        data, stations, reftimes, leadtimes, **kwargs
     )
-    air_temperature = temperature_ensavg(
-        data, stations, reftimes, leadtimes, ds=xr.Dataset()
-    )
+    air_temperature = temperature_ensavg(data, stations, reftimes, leadtimes, **kwargs)
 
     def e_from_t(t, a, b, c):
         return c * np.exp(a * t / (b + t))
@@ -631,17 +498,10 @@ def water_vapor_pressure_ensavg(
 @reuse
 @asarray
 def water_vapor_saturation_pressure_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
 
-    air_temperature = temperature_ensavg(
-        data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-    )
+    air_temperature = temperature_ensavg(data, stations, reftimes, leadtimes, **kwargs)
 
     def e_from_t(t, a, b, c):
         return c * np.exp(a * t / (b + t))
@@ -658,12 +518,7 @@ def water_vapor_saturation_pressure_ensavg(
 @reuse
 @asarray
 def wind_from_direction_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Calculate ensemble mean of wind direction
@@ -682,12 +537,7 @@ def wind_from_direction_ensavg(
 @reuse
 @asarray
 def wind_speed_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of wind speed
@@ -706,12 +556,7 @@ def wind_speed_ensavg(
 @reuse
 @asarray
 def wind_speed_ensstd(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble std of wind speed
@@ -730,19 +575,12 @@ def wind_speed_ensstd(
 @reuse
 @asarray
 def wind_speed_error(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Forecast error of the ensemble mean wind speed
     """
-    nwp = wind_speed_ensavg(
-        data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-    )
+    nwp = wind_speed_ensavg(data, stations, reftimes, leadtimes, **kwargs)
     obs = data["obs"][["wind_speed"]]
     obs = (
         obs.preproc.unstack_time(reftimes, leadtimes)
@@ -755,12 +593,7 @@ def wind_speed_error(
 @reuse
 @asarray
 def wind_speed_of_gust_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of wind speed gust
@@ -778,12 +611,7 @@ def wind_speed_of_gust_ensavg(
 @reuse
 @asarray
 def wind_speed_of_gust_ensstd(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble std of wind speed gust
@@ -801,19 +629,12 @@ def wind_speed_of_gust_ensstd(
 @reuse
 @asarray
 def wind_speed_of_gust_error(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Forecast error of the ensemble mean wind speed of gust
     """
-    nwp = wind_speed_of_gust_ensavg(
-        data, stations, reftimes, leadtimes, ds=xr.Dataset(), **kwargs
-    )
+    nwp = wind_speed_of_gust_ensavg(data, stations, reftimes, leadtimes, **kwargs)
     obs = data["obs"][["wind_speed_of_gust"]]
     obs = (
         obs.preproc.unstack_time(reftimes, leadtimes)
@@ -826,12 +647,7 @@ def wind_speed_of_gust_error(
 @reuse
 @asarray
 def wind_gust_factor_ensavg(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
     Calculate ensemble mean wind gust factor

--- a/mlpp_features/obs.py
+++ b/mlpp_features/obs.py
@@ -14,12 +14,7 @@ xr.set_options(keep_attrs=True)
 @reuse
 @asarray
 def wind_speed(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     return (
         data["obs"]
@@ -32,12 +27,7 @@ def wind_speed(
 @reuse
 @asarray
 def wind_speed_of_gust(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     return (
         data["obs"]
@@ -50,12 +40,7 @@ def wind_speed_of_gust(
 @reuse
 @asarray
 def nearest_wind_speed(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     return (
         data["obs"]
@@ -70,12 +55,7 @@ def nearest_wind_speed(
 @reuse
 @asarray
 def distance_to_nearest_wind_speed(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     return (
         data["obs"]
@@ -92,12 +72,7 @@ def distance_to_nearest_wind_speed(
 @reuse
 @asarray
 def nearest_wind_speed_of_gust(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     return (
         data["obs"]
@@ -112,12 +87,7 @@ def nearest_wind_speed_of_gust(
 @reuse
 @asarray
 def distance_to_nearest_wind_speed_of_gust(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     return (
         data["obs"]

--- a/mlpp_features/time.py
+++ b/mlpp_features/time.py
@@ -14,12 +14,7 @@ xr.set_options(keep_attrs=True)
 
 @asarray
 def cos_dayofyear(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.Dataset:
     """
     Compute the cosine of day-of-year
@@ -44,12 +39,7 @@ def cos_dayofyear(
 
 @asarray
 def cos_hourofday(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.Dataset:
     """
     Compute the cosine of hour-of-day
@@ -72,12 +62,7 @@ def cos_hourofday(
 
 @asarray
 def sin_dayofyear(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.Dataset:
     """
     Compute the sine of day-of-year
@@ -93,12 +78,7 @@ def sin_dayofyear(
 
 @asarray
 def sin_hourofday(
-    data: Dict[str, xr.Dataset],
-    stations,
-    reftimes,
-    leadtimes,
-    ds=xr.Dataset(),
-    **kwargs
+    data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.Dataset:
     """
     Compute the sine of hour-of-day

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -34,7 +34,7 @@ class TestFeatures:
             "obs": xr.Dataset(),
         }
         with pytest.raises(KeyError):
-            pipeline(empty_data, None, None, None, ds=xr.Dataset())
+            pipeline(empty_data, None, None, None)
 
     @pytest.mark.parametrize("pipeline,", pipelines)
     def test_features(self, pipeline):
@@ -47,7 +47,7 @@ class TestFeatures:
         stations = self._stations
         reftimes = pd.date_range("2000-01-01T00", "2000-01-02T00", periods=4)
         leadtimes = list(range(3))
-        da = pipeline(data, stations, reftimes, leadtimes, ds=xr.Dataset())
+        da = pipeline(data, stations, reftimes, leadtimes)
         assert isinstance(da, xr.DataArray)
         assert "variable" not in da.dims
         if "t" in da.dims:


### PR DESCRIPTION
Closes #5. 

This PR introduces a new decorator that allows to check whether a given feature is already present in the target dataset (the one where the results are accumulated), that is a `xr.Dataset` object passed as the last argument of a pipeline.

### Caveat:
The order matters! First one should compute the more "basic" variables, and then those that are derived from them.