### PR TITLE
Pass time arguments as objects

### DIFF
--- a/mlpp_features/nwp.py
+++ b/mlpp_features/nwp.py
@@ -15,7 +15,7 @@ xr.set_options(keep_attrs=True)
 
 @cache
 @out_format(units="degC")
-def air_temperature(
+def air_temperature_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
@@ -37,7 +37,7 @@ def air_temperature_ensavg(
     """
     Ensemble mean of temperature in °C
     """
-    t = air_temperature(data, stations, **kwargs)
+    t = air_temperature_ens(data, stations, **kwargs)
     return t.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -48,7 +48,7 @@ def air_temperature_ensctrl(
     """
     Control run temperature in °C
     """
-    t = air_temperature(data, stations, **kwargs)
+    t = air_temperature_ens(data, stations, **kwargs)
     return (
         t.isel(realization=0, drop=True)
         .to_dataset()
@@ -63,18 +63,18 @@ def air_temperature_ensstd(
     """
     Ensemble standard deviation of temperature in °C
     """
-    t = air_temperature(data, stations, **kwargs)
+    t = air_temperature_ens(data, stations, **kwargs)
     return t.std("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
 @out_format(units="degC")
-def air_temperature_dailyrange(
+def air_temperature_dailyrange_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of daily temperature range in °C
     """
-    t = air_temperature(data, stations, *args, **kwargs).to_dataset()
+    t = air_temperature_ens(data, stations, *args, **kwargs).to_dataset()
     t = t.assign_coords(time=t.forecast_reference_time + t.t.astype("timedelta64[h]"))
     daymax = t.preproc.daystat(xr.Dataset.max)
     daymin = t.preproc.daystat(xr.Dataset.min)
@@ -88,7 +88,7 @@ def air_temperature_dailyrange_ensavg(
     """
     Ensemble mean of daily temperature range in °C
     """
-    t = air_temperature(data, stations, **kwargs)
+    t = air_temperature_ens(data, stations, **kwargs)
     return t.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -144,13 +144,13 @@ def boundary_layer_height_ensctrl(
 
 
 @out_format()
-def cos_wind_from_direction(
+def cos_wind_from_direction_ens(
     data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwargs
 ) -> xr.DataArray:
     """
-    Calculate ensemble mean of cosine wind direction
+    Ensemble of cosine wind direction
     """
-    wdir = wind_from_direction(data, stations, reftimes, leadtimes, **kwargs)
+    wdir = wind_from_direction_ens(data, stations, reftimes, leadtimes, **kwargs)
     return np.cos(wdir * 2 * np.pi / 360)
 
 
@@ -161,7 +161,7 @@ def cos_wind_from_direction_ensavg(
     """
     Calculate ensemble mean of cosine wind direction
     """
-    wdir = cos_wind_from_direction(data, stations, reftimes, leadtimes, **kwargs)
+    wdir = cos_wind_from_direction_ens(data, stations, reftimes, leadtimes, **kwargs)
     return wdir.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -172,7 +172,7 @@ def cos_wind_from_direction_ensctrl(
     """
     Calculate ensemble control of cosine wind direction
     """
-    wdir = cos_wind_from_direction(data, stations, reftimes, leadtimes, **kwargs)
+    wdir = cos_wind_from_direction_ens(data, stations, reftimes, leadtimes, **kwargs)
     return (
         wdir.isel(realization=0, drop=True)
         .to_dataset()
@@ -181,14 +181,14 @@ def cos_wind_from_direction_ensctrl(
 
 
 @out_format(units="degC")
-def dew_point_depression(
+def dew_point_depression_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of dew point depression (T - T_d)
     """
-    t = air_temperature(data, stations, *args, **kwargs)
-    t_d = dew_point_temperature(data, stations, *args, **kwargs)
+    t = air_temperature_ens(data, stations, *args, **kwargs)
+    t_d = dew_point_temperature_ens(data, stations, *args, **kwargs)
     return (t - t_d).astype("float32")
 
 
@@ -199,7 +199,7 @@ def dew_point_depression_ensavg(
     """
     Ensemble mean of dew point depression (T - T_d)
     """
-    tdep = dew_point_depression(data, stations, reftimes, leadtimes, **kwargs)
+    tdep = dew_point_depression_ens(data, stations, reftimes, leadtimes, **kwargs)
     return tdep.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -210,7 +210,7 @@ def dew_point_depression_ensctrl(
     """
     Control run dew point depression (T - T_d)
     """
-    tdep = dew_point_depression(data, stations, reftimes, leadtimes, **kwargs)
+    tdep = dew_point_depression_ens(data, stations, reftimes, leadtimes, **kwargs)
     return (
         tdep.isel(realization=0, drop=True)
         .to_dataset()
@@ -220,7 +220,7 @@ def dew_point_depression_ensctrl(
 
 @cache
 @out_format(units="degC")
-def dew_point_temperature(
+def dew_point_temperature_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
@@ -242,7 +242,7 @@ def dew_point_temperature_ensavg(
     """
     Ensemble mean of dew point temperature in °C
     """
-    td = dew_point_temperature(data, stations, **kwargs)
+    td = dew_point_temperature_ens(data, stations, **kwargs)
     return td.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -253,7 +253,7 @@ def dew_point_temperature_ensctrl(
     """
     Control run dew point temperature in °C
     """
-    td = dew_point_temperature(data, stations, **kwargs)
+    td = dew_point_temperature_ens(data, stations, **kwargs)
     return (
         td.isel(realization=0, drop=True)
         .to_dataset()
@@ -262,15 +262,15 @@ def dew_point_temperature_ensctrl(
 
 
 @out_format(units="degC")
-def equivalent_potential_temperature(
+def equivalent_potential_temperature_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Control run equivalent potential temperature in °C
     """
-    t = air_temperature(data, stations, *args, **kwargs)
-    rh = relative_humidity(data, stations, *args, **kwargs)
-    p = surface_air_pressure(data, stations, *args, **kwargs)
+    t = air_temperature_ens(data, stations, *args, **kwargs)
+    rh = relative_humidity_ens(data, stations, *args, **kwargs)
+    p = surface_air_pressure_ens(data, stations, *args, **kwargs)
     return calc.equivalent_potential_temperature_from_t_rh_p(t, rh, p)
 
 
@@ -281,7 +281,7 @@ def equivalent_potential_temperature_ensavg(
     """
     Control run equivalent potential temperature in °C
     """
-    theta_e = equivalent_potential_temperature(data, stations, **kwargs)
+    theta_e = equivalent_potential_temperature_ens(data, stations, **kwargs)
     return (
         theta_e.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
     )
@@ -294,7 +294,7 @@ def equivalent_potential_temperature_ensctrl(
     """
     Control run equivalent potential temperature in °C
     """
-    theta_e = equivalent_potential_temperature(data, stations, **kwargs)
+    theta_e = equivalent_potential_temperature_ens(data, stations, **kwargs)
     return (
         theta_e.isel(realization=0, drop=True)
         .to_dataset()
@@ -354,7 +354,7 @@ def direct_downward_shortwave_radiation_ensavg(
 
 @cache
 @out_format(units="m s-1")
-def eastward_wind(data: Dict[str, xr.Dataset], stations, *args, **kwargs):
+def eastward_wind_ens(data: Dict[str, xr.Dataset], stations, *args, **kwargs):
     return (
         data["nwp"]
         .preproc.get("eastward_wind")
@@ -370,7 +370,7 @@ def eastward_wind_ensavg(
     """
     Ensemble mean of eastward wind in m/s
     """
-    u = eastward_wind(data, stations, **kwargs)
+    u = eastward_wind_ens(data, stations, **kwargs)
     return u.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -381,7 +381,7 @@ def eastward_wind_ensctrl(
     """
     Ensemble control of eastward wind in m/s
     """
-    u = eastward_wind(data, stations, **kwargs)
+    u = eastward_wind_ens(data, stations, **kwargs)
     return (
         u.isel(realization=0, drop=True)
         .to_dataset()
@@ -434,7 +434,7 @@ def model_height_difference(
 
 @cache
 @out_format(units="m s-1")
-def northward_wind(data: Dict[str, xr.Dataset], stations, *args, **kwargs):
+def northward_wind_ens(data: Dict[str, xr.Dataset], stations, *args, **kwargs):
     return (
         data["nwp"]
         .preproc.get("northward_wind")
@@ -450,7 +450,7 @@ def northward_wind_ensavg(
     """
     Ensemble mean of northward wind in m/s
     """
-    v = northward_wind(data, stations, **kwargs)
+    v = northward_wind_ens(data, stations, **kwargs)
     return v.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -461,7 +461,7 @@ def northward_wind_ensctrl(
     """
     Ensemble control of northward wind in m/s
     """
-    v = northward_wind(data, stations, **kwargs)
+    v = northward_wind_ens(data, stations, **kwargs)
     return (
         v.isel(realization=0, drop=True)
         .to_dataset()
@@ -470,14 +470,14 @@ def northward_wind_ensctrl(
 
 
 @out_format(units="degC")
-def potential_temperature(
+def potential_temperature_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of potential temperature in °C
     """
-    t = air_temperature(data, stations, *args, **kwargs)
-    p = surface_air_pressure(data, stations, *args, **kwargs)
+    t = air_temperature_ens(data, stations, *args, **kwargs)
+    p = surface_air_pressure_ens(data, stations, *args, **kwargs)
     return calc.potential_temperature_from_t_and_p(t, p)
 
 
@@ -488,7 +488,7 @@ def potential_temperature_ensavg(
     """
     Ensemble mean of potential temperature in °C
     """
-    v = potential_temperature(data, stations, **kwargs)
+    v = potential_temperature_ens(data, stations, **kwargs)
     return v.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -499,7 +499,7 @@ def potential_temperature_ensctrl(
     """
     Ensemble mean of potential temperature in °C
     """
-    v = potential_temperature(data, stations, **kwargs)
+    v = potential_temperature_ens(data, stations, **kwargs)
     return (
         v.isel(realization=0, drop=True)
         .to_dataset()
@@ -508,13 +508,13 @@ def potential_temperature_ensctrl(
 
 
 @out_format(units="hPa")
-def pressure_difference_BAS_LUG(
+def pressure_difference_BAS_LUG_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of pressure difference between Basel and Lugano in hPa
     """
-    p = surface_air_pressure(data, stations, **kwargs)
+    p = surface_air_pressure_ens(data, stations, **kwargs)
     return p.sel(station=["BAS", "LUG"]).diff("station").squeeze("station", drop=True)
 
 
@@ -525,7 +525,7 @@ def pressure_difference_BAS_LUG_ensavg(
     """
     Ensemble mean of pressure difference between Geneva and Güttingen in hPa
     """
-    pdiff = pressure_difference_BAS_LUG(data, stations, **kwargs)
+    pdiff = pressure_difference_BAS_LUG_ens(data, stations, **kwargs)
     return (
         pdiff.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
     )
@@ -538,7 +538,7 @@ def pressure_difference_BAS_LUG_ensctrl(
     """
     Ensemble control of pressure difference between Basel and Lugano in hPa
     """
-    pdiff = pressure_difference_BAS_LUG(data, stations, **kwargs)
+    pdiff = pressure_difference_BAS_LUG_ens(data, stations, **kwargs)
     return (
         pdiff.isel(realization=0, drop=True)
         .to_dataset()
@@ -547,13 +547,13 @@ def pressure_difference_BAS_LUG_ensctrl(
 
 
 @out_format(units="hPa")
-def pressure_difference_GVE_GUT(
+def pressure_difference_GVE_GUT_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble control of pressure difference between Geneva and Güttingen in hPa
     """
-    p = surface_air_pressure(data, stations, *args, **kwargs)
+    p = surface_air_pressure_ens(data, stations, *args, **kwargs)
     return p.sel(station=["GVE", "GUT"]).diff("station").squeeze("station", drop=True)
 
 
@@ -564,7 +564,7 @@ def pressure_difference_GVE_GUT_ensavg(
     """
     Ensemble mean of pressure difference between Geneva and Güttingen in hPa
     """
-    pdiff = pressure_difference_GVE_GUT(data, stations, **kwargs)
+    pdiff = pressure_difference_GVE_GUT_ens(data, stations, **kwargs)
     return (
         pdiff.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
     )
@@ -577,7 +577,7 @@ def pressure_difference_GVE_GUT_ensctrl(
     """
     Ensemble control of pressure difference between Geneva and Güttingen in hPa
     """
-    pdiff = pressure_difference_GVE_GUT(data, stations, **kwargs)
+    pdiff = pressure_difference_GVE_GUT_ens(data, stations, **kwargs)
     return (
         pdiff.isel(realization=0, drop=True)
         .to_dataset()
@@ -586,13 +586,13 @@ def pressure_difference_GVE_GUT_ensctrl(
 
 
 @out_format(units="%")
-def relative_humidity(
+def relative_humidity_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of relative humidity in %
     """
-    e = water_vapor_pressure(data, stations, *args, **kwargs)
+    e = water_vapor_pressure_ens(data, stations, *args, **kwargs)
     e_s = water_vapor_saturation_pressure(data, stations, *args, **kwargs)
     return (e / e_s * 100).astype("float32")
 
@@ -604,7 +604,7 @@ def relative_humidity_ensavg(
     """
     Ensemble mean of relative humidity in %
     """
-    rh = relative_humidity(data, stations, **kwargs)
+    rh = relative_humidity_ens(data, stations, **kwargs)
     return rh.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -615,7 +615,7 @@ def relative_humidity_ensctrl(
     """
     Control run relative humidity in %
     """
-    rh = relative_humidity(data, stations, **kwargs)
+    rh = relative_humidity_ens(data, stations, **kwargs)
     return (
         rh.isel(realization=0, drop=True)
         .to_dataset()
@@ -624,13 +624,13 @@ def relative_humidity_ensctrl(
 
 
 @out_format()
-def sin_wind_from_direction(
+def sin_wind_from_direction_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Calculate ensemble mean of sine wind direction
     """
-    wdir = wind_from_direction(data, stations, *args, **kwargs)
+    wdir = wind_from_direction_ens(data, stations, *args, **kwargs)
     return np.sin(wdir * 2 * np.pi / 360)
 
 
@@ -641,7 +641,7 @@ def sin_wind_from_direction_ensavg(
     """
     Calculate ensemble mean of sine wind direction
     """
-    wdir = sin_wind_from_direction(data, stations, **kwargs)
+    wdir = sin_wind_from_direction_ens(data, stations, **kwargs)
     return wdir.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -652,7 +652,7 @@ def sin_wind_from_direction_ensctrl(
     """
     Calculate ensemble control of sine wind direction
     """
-    wdir = sin_wind_from_direction(data, stations, **kwargs)
+    wdir = sin_wind_from_direction_ens(data, stations, **kwargs)
     return (
         wdir.isel(realization=0, drop=True)
         .to_dataset()
@@ -662,7 +662,7 @@ def sin_wind_from_direction_ensctrl(
 
 @cache
 @out_format(units="g kg-1")
-def specific_humidity(
+def specific_humidity_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
@@ -683,7 +683,7 @@ def specific_humidity_ensavg(
     """
     Ensemble mean of specific humidity in g/kg
     """
-    q = specific_humidity(data, stations, **kwargs)
+    q = specific_humidity_ens(data, stations, **kwargs)
     return q.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -694,7 +694,7 @@ def specific_humidity_ensctrl(
     """
     Control run specific humidity in g/kg
     """
-    q = specific_humidity(data, stations, **kwargs)
+    q = specific_humidity_ens(data, stations, **kwargs)
     return (
         q.isel(realization=0, drop=True)
         .to_dataset()
@@ -721,7 +721,7 @@ def sunshine_duration_ensavg(
 
 @cache
 @out_format(units="hPa")
-def surface_air_pressure(
+def surface_air_pressure_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
@@ -743,7 +743,7 @@ def surface_air_pressure_ensavg(
     """
     Ensemble mean of surface pressure in hPa
     """
-    q = surface_air_pressure(data, stations, **kwargs)
+    q = surface_air_pressure_ens(data, stations, **kwargs)
     return q.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -754,7 +754,7 @@ def surface_air_pressure_ensctrl(
     """
     Control run surface pressure in hPa
     """
-    q = surface_air_pressure(data, stations, **kwargs)
+    q = surface_air_pressure_ens(data, stations, **kwargs)
     return (
         q.isel(realization=0, drop=True)
         .to_dataset()
@@ -829,14 +829,14 @@ def sx_500m_ensctrl(
 
 
 @out_format(units="g kg-1")
-def water_vapor_mixing_ratio(
+def water_vapor_mixing_ratio_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble mean of water vapor mixing ratio in g/kg
     """
-    e = water_vapor_pressure(data, stations, *args, **kwargs)
-    p = surface_air_pressure(data, stations, *args, **kwargs)
+    e = water_vapor_pressure_ens(data, stations, *args, **kwargs)
+    p = surface_air_pressure_ens(data, stations, *args, **kwargs)
     return calc.mixing_ratio_from_p_and_e(p, e)
 
 
@@ -847,7 +847,7 @@ def water_vapor_mixing_ratio_ensavg(
     """
     Ensemble mean of water vapor mixing ratio in g/kg
     """
-    r = water_vapor_mixing_ratio(data, stations, **kwargs)
+    r = water_vapor_mixing_ratio_ens(data, stations, **kwargs)
     return r.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -858,7 +858,7 @@ def water_vapor_mixing_ratio_ensctrl(
     """
     Control run water vapor mixing ratio in g/kg
     """
-    r = water_vapor_mixing_ratio(data, stations, **kwargs)
+    r = water_vapor_mixing_ratio_ens(data, stations, **kwargs)
     return (
         r.isel(realization=0, drop=True)
         .to_dataset()
@@ -868,14 +868,14 @@ def water_vapor_mixing_ratio_ensctrl(
 
 @cache
 @out_format(units="hPa")
-def water_vapor_pressure(
+def water_vapor_pressure_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Ensemble of water vapor partial pressure in hPa
     """
-    t_d = dew_point_temperature(data, stations, *args, **kwargs)
-    t = air_temperature(data, stations, *args, **kwargs)
+    t_d = dew_point_temperature_ens(data, stations, *args, **kwargs)
+    t = air_temperature_ens(data, stations, *args, **kwargs)
     return calc.water_vapor_pressure_from_t_and_td(t, t_d)
 
 
@@ -886,7 +886,7 @@ def water_vapor_pressure_ensavg(
     """
     Ensemble mean of water vapor partial pressure
     """
-    e = water_vapor_pressure(data, stations, **kwargs)
+    e = water_vapor_pressure_ens(data, stations, **kwargs)
     return e.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -897,7 +897,7 @@ def water_vapor_pressure_ensctrl(
     """
     Control run water vapor partial pressure
     """
-    e = water_vapor_pressure(data, stations, **kwargs)
+    e = water_vapor_pressure_ens(data, stations, **kwargs)
     return (
         e.isel(realization=0, drop=True)
         .to_dataset()
@@ -912,7 +912,7 @@ def water_vapor_saturation_pressure(
     """
     Ensemble mean of water vapor partial pressure at saturation in hPa
     """
-    t = air_temperature(data, stations, *args, **kwargs)
+    t = air_temperature_ens(data, stations, *args, **kwargs)
     return calc.water_vapor_saturation_pressure_from_t(t)
 
 
@@ -943,14 +943,14 @@ def water_vapor_saturation_pressure_ensctrl(
 
 
 @out_format(units="degrees")
-def wind_from_direction(
+def wind_from_direction_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Calculate ensemble control of wind direction
     """
-    u = eastward_wind(data, stations, *args, **kwargs)
-    v = northward_wind(data, stations, *args, **kwargs)
+    u = eastward_wind_ens(data, stations, *args, **kwargs)
+    v = northward_wind_ens(data, stations, *args, **kwargs)
     out = (270 - 180 / np.pi * np.arctan2(v, u)) % 360
     return out.astype("float32")
 
@@ -962,7 +962,7 @@ def wind_from_direction_ensavg(
     """
     Calculate ensemble mean of wind direction
     """
-    d = wind_from_direction(data, stations, **kwargs)
+    d = wind_from_direction_ens(data, stations, **kwargs)
     return d.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -973,7 +973,7 @@ def wind_from_direction_ensctrl(
     """
     Calculate ensemble control of wind direction
     """
-    d = wind_from_direction(data, stations, **kwargs)
+    d = wind_from_direction_ens(data, stations, **kwargs)
     return (
         d.isel(realization=0, drop=True)
         .to_dataset()
@@ -982,9 +982,9 @@ def wind_from_direction_ensctrl(
 
 
 @out_format(units="m s-1")
-def wind_speed(data: Dict[str, xr.Dataset], stations, *args, **kwargs):
-    u = eastward_wind(data, stations, *args, **kwargs)
-    v = northward_wind(data, stations, *args, **kwargs)
+def wind_speed_ens(data: Dict[str, xr.Dataset], stations, *args, **kwargs):
+    u = eastward_wind_ens(data, stations, *args, **kwargs)
+    v = northward_wind_ens(data, stations, *args, **kwargs)
     return np.sqrt(u**2 + v**2).astype("float32")
 
 
@@ -995,7 +995,7 @@ def wind_speed_ensavg(
     """
     Ensemble mean of wind speed
     """
-    uv = wind_speed(data, stations, **kwargs)
+    uv = wind_speed_ens(data, stations, **kwargs)
     return uv.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -1024,7 +1024,7 @@ def wind_speed_ensctrl(
     """
     Ensemble control of wind speed
     """
-    uv = wind_speed(data, stations, **kwargs)
+    uv = wind_speed_ens(data, stations, **kwargs)
     return (
         uv.isel(realization=0, drop=True)
         .to_dataset()
@@ -1057,13 +1057,13 @@ def wind_speed_ensstd(
     """
     Ensemble std of wind speed
     """
-    uv = wind_speed(data, stations, **kwargs)
+    uv = wind_speed_ens(data, stations, **kwargs)
     return uv.std("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
 @cache
 @out_format(units="m s-1")
-def wind_speed_of_gust(
+def wind_speed_of_gust_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
@@ -1084,7 +1084,7 @@ def wind_speed_of_gust_ensavg(
     """
     Ensemble mean of wind speed gust
     """
-    ug = wind_speed_of_gust(data, stations, **kwargs)
+    ug = wind_speed_of_gust_ens(data, stations, **kwargs)
     return ug.mean("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
@@ -1113,7 +1113,7 @@ def wind_speed_of_gust_ensctrl(
     """
     Ensemble control of wind speed of gust
     """
-    ug = wind_speed_of_gust(data, stations, **kwargs)
+    ug = wind_speed_of_gust_ens(data, stations, **kwargs)
     return (
         ug.isel(realization=0, drop=True)
         .to_dataset()
@@ -1146,19 +1146,19 @@ def wind_speed_of_gust_ensstd(
     """
     Ensemble std of wind speed gust
     """
-    ug = wind_speed_of_gust(data, stations, **kwargs)
+    ug = wind_speed_of_gust_ens(data, stations, **kwargs)
     return ug.std("realization").to_dataset().preproc.align_time(reftimes, leadtimes)
 
 
 @out_format()
-def wind_gust_factor(
+def wind_gust_factor_ens(
     data: Dict[str, xr.Dataset], stations, *args, **kwargs
 ) -> xr.DataArray:
     """
     Calculate ensemble of wind gust factor
     """
-    speed = wind_speed(data, stations, *args, **kwargs)
-    gust = wind_speed_of_gust(data, stations, *args, **kwargs)
+    speed = wind_speed_ens(data, stations, *args, **kwargs)
+    gust = wind_speed_of_gust_ens(data, stations, *args, **kwargs)
     return (gust + 1.0) / (speed + 1.0)
 
 
@@ -1169,7 +1169,7 @@ def wind_gust_factor_ensavg(
     """
     Calculate ensemble mean of wind gust factor
     """
-    gust_factor = wind_gust_factor(data, stations, **kwargs)
+    gust_factor = wind_gust_factor_ens(data, stations, **kwargs)
     return (
         gust_factor.mean("realization")
         .to_dataset()
@@ -1184,7 +1184,7 @@ def wind_gust_factor_ensctrl(
     """
     Calculate ensemble control of wind gust factor
     """
-    gust_factor = wind_gust_factor(data, stations, **kwargs)
+    gust_factor = wind_gust_factor_ens(data, stations, **kwargs)
     return (
         gust_factor.isel(realization=0, drop=True)
         .to_dataset()

--- a/mlpp_features/nwp.py
+++ b/mlpp_features/nwp.py
@@ -397,13 +397,12 @@ def leadtime(data: Dict[str, xr.Dataset], stations, reftimes, leadtimes, **kwarg
     if len(data["nwp"]) == 0:
         raise KeyError([])
     ds = data["nwp"]
-    return (
-        ds.drop_vars(ds.data_vars)
-        .drop_dims(("x", "y", "realization"), errors="ignore")
-        .preproc.align_time(reftimes, leadtimes)
-        .reset_coords("leadtime")
-        .astype("float32")
-    )
+    ds = ds.drop_vars(ds.data_vars)
+    ds = ds.drop_dims(("x", "y", "realization"), errors="ignore")
+    ds = ds.preproc.align_time(reftimes, leadtimes)
+    ds = ds.reset_coords("leadtime")
+    ds["leadtime"] = ds.leadtime.astype("timedelta64[h]") // np.timedelta64(1, "h")
+    return ds.astype("float32")
 
 
 @out_format(units="m")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def nwp_dataset():
 
         n_members = 2
         reftimes = pd.date_range("2000-01-01T00", "2000-01-02T00", periods=3)
-        leadtimes = [1, 2, 3]
+        leadtimes = np.array([1, 2, 3], dtype="timedelta64[h]")
 
         # define dummy dimensions
         n_reftimes = len(reftimes)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -47,13 +47,15 @@ class TestFeatures:
         }
         stations = self._stations
         reftimes = pd.date_range("2000-01-01T00", "2000-01-02T00", periods=4)
-        leadtimes = list(range(3))
+        leadtimes = np.arange(3).astype("timedelta64[h]")
         with tempfile.TemporaryDirectory() as tmp_dir:
             da = pipeline(data, stations, reftimes, leadtimes, tmp_dir=tmp_dir)
         assert isinstance(da, xr.DataArray)
         assert da.dtype == "float32"
-        assert "variable" not in da.dims
+        if "forecast_reference_time" in da.dims:
+            assert da.forecast_reference_time.dtype == np.dtype("datetime64[ns]")
         if "t" in da.dims:
-            assert da.t.dtype == int
+            assert da.t.dtype == np.dtype("timedelta64[ns]")
+        assert "variable" not in da.dims
         assert all([coord in KEEP_STA_COORDS + list(da.dims) for coord in da.coords])
         assert all([dim in da.coords for dim in da.dims])


### PR DESCRIPTION
Now all reftimes/leadtimes all always encoded as datetime64 or timedelta64 objects.